### PR TITLE
Checks for output with unbounded sensitivity

### DIFF
--- a/sdk/opendp/smartnoise/_ast/ast.py
+++ b/sdk/opendp/smartnoise/_ast/ast.py
@@ -400,6 +400,8 @@ class TableColumn(SqlExpr):
         if self.valtype in ["int", "float"]:
             if self.minval is not None and self.maxval is not None:
                 return max(abs(self.maxval), abs(self.minval))
+            else:
+                return np.inf #unbounded
         elif self.valtype == "boolean":
             return 1
         else:

--- a/sdk/opendp/smartnoise/sql/private_reader.py
+++ b/sdk/opendp/smartnoise/sql/private_reader.py
@@ -181,6 +181,9 @@ class PrivateReader(Reader):
             if is_group_key[idx]:
                 sens[idx] = None
 
+        if any([s is np.inf for s in sens]):
+            raise ValueError("Query is attempting to query an unbounded column that isn't part of the grouping key")
+
         kc_pos = None
         kcc_pos = []
         for idx in range(len(syms)):

--- a/tests/sdk/metadata/test_bounds_check.py
+++ b/tests/sdk/metadata/test_bounds_check.py
@@ -1,0 +1,57 @@
+import io
+import pytest
+from opendp.smartnoise.metadata.collection import CollectionMetadata
+
+class TestMetaBounds:
+    def test_meta_from_string(self):
+        meta_good = """col:
+    ? ''
+    : table:
+        duration:
+            type: float
+        id:
+            private_id: true
+            type: int
+        max_ids: 1
+        row_privacy: false
+        rows: 1000
+        sample_max_ids: true
+engine: pandas"""
+        file = io.StringIO(meta_good)
+        c = CollectionMetadata.from_file(file)
+    def test_meta_bad_float(self):
+        meta_bad_float = """col:
+    ? ''
+    : table:
+        duration:
+            type: float
+        id:
+            private_id: true
+            type: int
+        max_ids: 1
+        row_privacy: false
+        rows: 1000
+        sample_max_ids: true
+engine: pandas"""
+        file = io.StringIO(meta_bad_float)
+        c = CollectionMetadata.from_file(file)
+        assert(c["table"]["duration"].unbounded)
+    def test_meta_bad_int(self):
+        meta_bad_float = """col:
+    ? ''
+    : table:
+        id:
+            private_id: true
+            type: int
+        events:
+            type: int
+        max_ids: 1
+        row_privacy: false
+        rows: 1000
+        sample_max_ids: true
+engine: pandas"""
+        file = io.StringIO(meta_bad_float)
+        c = CollectionMetadata.from_file(file)
+        assert(c["table"]["events"].unbounded)
+
+

--- a/tests/sdk/query/test_query_error.py
+++ b/tests/sdk/query/test_query_error.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+import copy
+import pytest
+
+import pandas as pd
+from pandasql import sqldf
+import math
+
+from opendp.smartnoise.metadata import CollectionMetadata
+from opendp.smartnoise.sql import PrivateReader, PandasReader
+from opendp.smartnoise.sql.parse import QueryParser
+
+git_root_dir = subprocess.check_output("git rev-parse --show-toplevel".split(" ")).decode("utf-8").strip()
+
+meta_path = os.path.join(git_root_dir, os.path.join("service", "datasets", "PUMS.yaml"))
+csv_path = os.path.join(git_root_dir, os.path.join("service", "datasets", "PUMS.csv"))
+
+schema = CollectionMetadata.from_file(meta_path)
+df = pd.read_csv(csv_path)
+
+class TestQueryError:
+    def test_err1(self):
+        s = copy.copy(schema)
+        s["PUMS.PUMS"]["income"].maxval = None
+        reader = PandasReader(df, s)
+        private_reader = PrivateReader(reader, s, 4.0)
+        with pytest.raises(ValueError):
+            rs = private_reader.execute_df("SELECT SUM(income) FROM PUMS.PUMS")
+    def test_err2(self):
+        s = copy.copy(schema)
+        s["PUMS.PUMS"]["income"].minval = None
+        reader = PandasReader(df, s)
+        private_reader = PrivateReader(reader, s, 4.0)
+        with pytest.raises(ValueError):
+            rs = private_reader.execute_df("SELECT income, SUM(income) FROM PUMS.PUMS GROUP BY income")
+    def test_ok1(self):
+        s = copy.copy(schema)
+        s["PUMS.PUMS"]["income"].maxval = None
+        reader = PandasReader(df, s)
+        private_reader = PrivateReader(reader, s, 4.0)
+        rs = private_reader.execute_df("SELECT income FROM PUMS.PUMS GROUP BY income")
+    def test_ok2(self):
+        s = copy.copy(schema)
+        s["PUMS.PUMS"]["income"].maxval = None
+        reader = PandasReader(df, s)
+        private_reader = PrivateReader(reader, s, 4.0)
+        rs = private_reader.execute_df("SELECT COUNT(income) FROM PUMS.PUMS")


### PR DESCRIPTION
Fix for #317.  AST was not propagating unbounded sensitivity to resolved symbols.  

When a column has unbounded sensitivity, we now allow queries like `COUNT(col`) and `SELECT col GROUP BY col`, but prohibit queries like `SUM(col)` or `AVG(col)`.