### PR TITLE
update opendp.io to opendp.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Samples of DP SQL functionality: [here](https://github.com/opendifferentialpriva
 
 - Please use [GitHub issues](https://github.com/opendifferentialprivacy/smartnoise-sdk/issues) for bug reports, feature requests, install issues, and ideas.
 - [Gitter](https://gitter.im/opendifferentialprivacy/SmartNoise) is available for general chat and online discussions.
-- For other requests, please contact us at [smartnoise@opendp.io](mailto:smartnoise@opendp.io).
+- For other requests, please contact us at [smartnoise@opendp.org](mailto:smartnoise@opendp.org).
   - _Note: We encourage you to use [GitHub issues](https://github.com/opendifferentialprivacy/smartnoise-sdk/issues), especially for bugs._
 
 ## Releases and Contributing


### PR DESCRIPTION
Update smartnoise@opendp.io to smartnoise@opendp.org
(Note, both addresses work and forward to the support channel)